### PR TITLE
Add jruby support

### DIFF
--- a/lib/Voyeur/converter.rb
+++ b/lib/Voyeur/converter.rb
@@ -47,7 +47,7 @@ module Voyeur
       command = "ffmpeg -y -i #{@input_media.filename} #{self.convert_options} #{@output_media.filename}"
       out, err = ""
 
-      status = Open4::popen4(command) do |pid, stdin, stdout, stderr|
+      OPEN4::popen4(command) do |pid, stdin, stdout, stderr|
         err = ''
         out = ''
         stderr.each("r") do |line|
@@ -58,9 +58,9 @@ module Voyeur
         end
       end
 
-      error_message = err.split('\n').last
+      error_message = err.split("\n").last
 
-      @status = { status: status.exitstatus, stdout: out, stderr: err,
+      @status = { status: $?.exitstatus, stdout: out, stderr: err,
                   error_message: error_message, media: @output_media }
       return @status
     end

--- a/lib/Voyeur/media.rb
+++ b/lib/Voyeur/media.rb
@@ -10,7 +10,7 @@ module Voyeur
 
     def get_info
       output = ''
-      status = Open4::popen4("ffmpeg -i #{@filename}") do |pid, stdin, stdout, stderr|
+      OPEN4::popen4("ffmpeg -i #{@filename}") do |pid, stdin, stdout, stderr|
         output = stderr.read.strip
       end
       @raw_duration = $1 if output =~ /Duration: (\d+:\d+:\d+.\d+)/

--- a/lib/voyeur.rb
+++ b/lib/voyeur.rb
@@ -10,3 +10,7 @@ require "Voyeur/audio_converters/aac"
 require "Voyeur/audio_converters/ogg"
 require "Voyeur/media_time"
 require 'open4'
+
+module Voyeur
+  OPEN4 = RUBY_PLATFORM =~ /java/ ? IO : Open4
+end


### PR DESCRIPTION
The open4 gem isn't compatible with jruby. Open3.popen3 is supported by both platforms, but has some annoying bugs like not yielding anything until after the conversion is finished which is crucial.

We can use IO.popen4 for jruby, which provides the same functionality.
