### PR TITLE
encode ffmpeg file info output to binary

### DIFF
--- a/lib/Voyeur/converter.rb
+++ b/lib/Voyeur/converter.rb
@@ -51,7 +51,7 @@ module Voyeur
         err = ''
         out = ''
         stderr.each("r") do |line|
-          err += line
+          err += line.force_encoding('BINARY')
           if line =~ /time=(\d+:\d+:\d+.\d+)/
             yield $1 if block_given?
           end

--- a/lib/Voyeur/media.rb
+++ b/lib/Voyeur/media.rb
@@ -11,7 +11,7 @@ module Voyeur
     def get_info
       output = ''
       status = Open4::popen4("ffmpeg -i #{@filename}") do |pid, stdin, stdout, stderr|
-        output = stderr.read.strip
+        output = stderr.read.strip.force_encoding('BINARY')
       end
       @raw_duration = $1 if output =~ /Duration: (\d+:\d+:\d+.\d+)/
     end


### PR DESCRIPTION
Sometimes ffmpeg outputs file info with invalid bytes, thus we can't use regexp on an invalid output to parse it. After forcing an invalid output to binary format we can use regexp to parse it.

Invalid output example:

```
$ ffmpeg -i test.avi
ffmpeg version 2.1.4 Copyright (c) 2000-2014 the FFmpeg developers
  built on Mar 25 2014 16:28:00 with Apple LLVM version 5.1 (clang-503.0.38) (based on LLVM 3.4svn)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/2.1.4 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-nonfree --enable-hardcoded-tables --enable-avresample --enable-vda --cc=clang --host-cflags= --host-ldflags= --enable-libx264 --enable-libfaac --enable-libmp3lame --enable-libxvid --enable-libvorbis --enable-libvpx
  libavutil      52. 48.101 / 52. 48.101
  libavcodec     55. 39.101 / 55. 39.101
  libavformat    55. 19.104 / 55. 19.104
  libavdevice    55.  5.100 / 55.  5.100
  libavfilter     3. 90.100 /  3. 90.100
  libavresample   1.  1.  0 /  1.  1.  0
  libswscale      2.  5.101 /  2.  5.101
  libswresample   0. 17.104 /  0. 17.104
  libpostproc    52.  3.100 / 52.  3.100
[avi @ 0x7fc574004a00] non-interleaved AVI
Input #0, avi, from 'test.avi':
  Metadata:
    encoder         : AVI-Mux GUI 1.17.7, Aug  8 2006  20:59:17�
    JUNK            :
  Duration: 00:22:20.67, start: 0.000000, bitrate: 1091 kb/s
    Stream #0:0: Video: mpeg4 (Advanced Simple Profile) (XVID / 0x44495658), yuv420p, 576x432 [SAR 1:1 DAR 4:3], 23.98 tbr, 23.98 tbn, 23.98 tbc
    Stream #0:1: Audio: mp3 (U[0][0][0] / 0x0055), 48000 Hz, stereo, s16p, 107 kb/s
At least one output file must be specified
```
